### PR TITLE
Use static config.json instead of hardcoding the path; Fixes #2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app/Lightspeed-react
 RUN npm install
 
 # configure ip, hardcoded to webrtc container address (8080) for now
-RUN sed -i "s|stream.gud.software|localhost|g" src/wsUrl.js
+RUN sed -i "s|stream.gud.software|localhost|g" public/config.json
 
 # build it
 RUN npm run build

--- a/README.md
+++ b/README.md
@@ -92,17 +92,20 @@ npm install
 <!-- USAGE EXAMPLES -->
 
 ## Usage
-First you need to configure the websocket url in `src/wsUrl.js`. If you are using an IP then it will be the public IP of your machine if you have DNS then it will be your hostname.
-
-You can host the static site locally using `serve`
-
+First build the frontend
 ```sh
 cd Lightspeed-react
 npm run build
+```
+
+You should then configure the websocket URL in `config.json` in the `build` directory.
+
+Now you can host the static site locally, by using `serve` for example
+```sh
 serve -s build -l 80
 ```
 
-This will serve the build folder on port 80 of your machine meaning it can be retrevied via a browser by either going to your machines public IP or hostname
+This will serve the build folder on port 80 of your machine meaning it can be retrieved via a browser by either going to your machines public IP or hostname
 
 <!-- _For more examples, please refer to the [Documentation](https://example.com)_ -->
 

--- a/public/config.json
+++ b/public/config.json
@@ -1,0 +1,3 @@
+{
+  "wsUrl": "ws://stream.gud.software:8080/websocket"
+}

--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ class Main extends React.Component {
       isLoaded: false,
       error: null,
 
+      wsUrl: null,
       ws: null,
     };
   }
@@ -19,13 +20,17 @@ class Main extends React.Component {
       .then(res => res.json())
       .then(
         (result) => {
-          if (result.hasOwnProperty("wsUrl"))
-            this.connect(result.wsUrl);
-          else
+          if (result.hasOwnProperty("wsUrl")) {
+            this.setState({
+              wsUrl: result.wsUrl
+            });
+            this.connect();
+          } else {
             this.setState({
               isLoaded: true,
               error: "config.json is invalid"
             })
+          }
         },
         (error) => {
           this.setState({
@@ -37,8 +42,9 @@ class Main extends React.Component {
 
   timeout = 250;
 
-  connect = (url) => {
-    var ws = new WebSocket(url);
+  connect = () => {
+    const {wsUrl} = this.state;
+    var ws = new WebSocket(wsUrl);
     let that = this;
     var connectInterval;
 

--- a/src/App.js
+++ b/src/App.js
@@ -22,7 +22,10 @@ class Main extends React.Component {
           if (result.hasOwnProperty("wsUrl"))
             this.connect(result.wsUrl);
           else
-            console.error("config.json is invalid")
+            this.setState({
+              isLoaded: true,
+              error: "config.json is invalid"
+            })
         },
         (error) => {
           this.setState({
@@ -75,11 +78,12 @@ class Main extends React.Component {
   };
 
   check = () => {
-    const {ws, isLoaded} = this.state;
-    if (isLoaded && (!ws || ws.readyState == WebSocket.CLOSED)) this.connect(); //check if websocket instance is closed, if so call `connect` function.
+    const {ws} = this.state;
+    if (!ws || ws.readyState == WebSocket.CLOSED) this.connect(); //check if websocket instance is closed, if so call `connect` function.
   };
 
   render() {
+    // TODO: check isLoaded and error in state and show error if needed?
     return <App websocket={this.state.ws}></App>;
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -89,8 +89,13 @@ class Main extends React.Component {
   };
 
   render() {
-    // TODO: check isLoaded and error in state and show error if needed?
-    return <App websocket={this.state.ws}></App>;
+    const {error} = this.state;
+    if (!error)
+      return <App websocket={this.state.ws}></App>;
+    else {
+      console.error(error)
+      return null;
+    }
   }
 }
 

--- a/src/wsUrl.js
+++ b/src/wsUrl.js
@@ -1,4 +1,0 @@
-//The websocket URL will be different depending on your configuration. 
-//For example if you are just using an IP addr it will be ws://YOURIP:8080/websocket
-//If you have DNS configured it will be ws://YOURHOSTNAME:8080/websocket
-export const url = "ws://stream.gud.software:8080/websocket";


### PR DESCRIPTION
# Meta
- Fixes #2

# Summary
Instead of hardcoding the URL to the websocket, this PR changes that to a `config.json` that lives in `public/`. That way it can be adjusted without needing to recompile the JS.

# TODO
- [x] Update README instructions
- [ ] Update README instructions on [Project Lightspeed repo](https://github.com/GRVYDEV/Project-Lightspeed)
