### PR TITLE
Dockerfile improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
+.git
+.dockerignore
+.gitignore
 Dockerfile
 README.md
 LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN npm run build
 FROM nginx:${NGINX_VERSION}-alpine
 ENV WEBSOCKET_HOST=localhost
 ENV WEBSOCKET_PORT=8080
-EXPOSE 8080/tcp 80/tcp
+EXPOSE 80/tcp
 COPY --chown=1000 docker/entrypoint.sh /docker-entrypoint.d/entrypoint.sh
 COPY --chown=1000 docker/config.json.template /config.json.template
 COPY --from=builder --chown=1000 /app/Lightspeed-react/build /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN npm run build
 FROM nginx:${NGINX_VERSION}-alpine
 ENV WEBSOCKET_HOST=localhost
 ENV WEBSOCKET_PORT=8080
-
+EXPOSE 8000/tcp 80/tcp
 COPY --chown=1000 docker/entrypoint.sh /docker-entrypoint.d/entrypoint.sh
 COPY --chown=1000 docker/config.json.template /config.json.template
 COPY --from=builder --chown=1000 /app/Lightspeed-react/build /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,14 @@ ARG ALPINE_VERSION=3.12
 ARG NODE_VERSION=15
 ARG NGINX_VERSION=1.19.6
 
-# multistage - builder image
 FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION} AS builder
 WORKDIR /app/Lightspeed-react
-# Layer caching for node modules
 COPY package.json package-lock.json ./
 RUN npm install
 COPY . .
-
-# build it
 RUN npm run build
 
-# runtime image
+
 FROM nginx:${NGINX_VERSION}-alpine
 ENV WEBSOCKET_HOST=localhost
 ENV WEBSOCKET_PORT=8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN npm run build
 FROM nginx:${NGINX_VERSION}-alpine
 ENV WEBSOCKET_HOST=localhost
 ENV WEBSOCKET_PORT=8080
-EXPOSE 8000/tcp 80/tcp
+EXPOSE 8080/tcp 80/tcp
 COPY --chown=1000 docker/entrypoint.sh /docker-entrypoint.d/entrypoint.sh
 COPY --chown=1000 docker/config.json.template /config.json.template
 COPY --from=builder --chown=1000 /app/Lightspeed-react/build /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG ALPINE_VERSION=3.12
 ARG NODE_VERSION=15
+ARG NGINX_VERSION=1.19.6
 
 # multistage - builder image
 FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION} AS builder
@@ -13,8 +14,10 @@ COPY . .
 RUN npm run build
 
 # runtime image
-FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION}
-USER 1000
-ENTRYPOINT [ "/entrypoint.sh" ]
-COPY --chown=1000 entrypoint.sh ./
+FROM nginx:${NGINX_VERSION}-alpine
+ENV WEBSOCKET_HOST=localhost
+ENV WEBSOCKET_PORT=8080
+
+COPY --chown=1000 docker/entrypoint.sh /docker-entrypoint.d/entrypoint.sh
+COPY --chown=1000 docker/config.json.template /config.json.template
 COPY --from=builder --chown=1000 /app/Lightspeed-react/build /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,12 @@ COPY package.json package-lock.json ./
 RUN npm install
 COPY . .
 
-# configure ip, hardcoded to webrtc container address (8080) for now
-RUN sed -i "s|stream.gud.software|localhost|g" public/config.json
-
 # build it
 RUN npm run build
 
 # runtime image
 FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION}
 USER 1000
+ENTRYPOINT [ "/entrypoint.sh" ]
+COPY --chown=1000 entrypoint.sh ./
 COPY --from=builder --chown=1000 /app/Lightspeed-react/build /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -90,8 +90,10 @@ This is one of three components required for Project Lightspeed. Project Lightsp
 
     ```sh
     docker run -it --rm \
-      -p 8000:80/tcp -p 8080:8080/tcp \
-      -e WEBSOCKET_HOST=localhost -e WEBSOCKET_PORT=8080 grvydev/lightspeed-react
+      -p 8000:80/tcp \
+      -e WEBSOCKET_HOST=localhost \
+      -e WEBSOCKET_PORT=8080 \
+      grvydev/lightspeed-react
     ```
 
 1. You can now access it at [localhost:8000](http://localhost:8000) and the websocket port is published on port `8080`.

--- a/README.md
+++ b/README.md
@@ -75,13 +75,36 @@ This is one of three components required for Project Lightspeed. Project Lightsp
 
 ## Getting Started
 
+## Setup
+
+### Docker
+
+1. Install [git](https://git-scm.com/downloads)
+1. Build the image from the master branch with:
+
+    ```sh
+    docker build -t grvydev/lightspeed-react https://github.com/GRVYDEV/Lightspeed-react.git
+    ```
+
+1. Run it with
+
+    ```sh
+    docker run -it --rm \
+      -p 8000:80/tcp -p 8080:8080/tcp \
+      -e WEBSOCKET_HOST=localhost -e WEBSOCKET_PORT=8080 grvydev/lightspeed-react
+    ```
+
+1. You can now access it at [localhost:8000](http://localhost:8000) and the websocket port is published on port `8080`.
+
+### Locally
+
 To get a local copy up and running follow these simple steps.
 
-### Prerequisites
+#### Prerequisites
 
 In order to run this npm is required. Installation instructions can be found <a href="https://www.rust-lang.org/tools/https://www.npmjs.com/get-npm">here</a>. Npm Serve is required as well if you want to host this on your machine. That can be found <a href="https://www.npmjs.com/package/serve">here</a>
 
-### Installation
+#### Installation
 
 ```sh
 git clone https://github.com/GRVYDEV/Lightspeed-react.git
@@ -91,8 +114,10 @@ npm install
 
 <!-- USAGE EXAMPLES -->
 
-## Usage
+#### Usage
+
 First build the frontend
+
 ```sh
 cd Lightspeed-react
 npm run build
@@ -101,6 +126,7 @@ npm run build
 You should then configure the websocket URL in `config.json` in the `build` directory.
 
 Now you can host the static site locally, by using `serve` for example
+
 ```sh
 serve -s build -l 80
 ```

--- a/README.md
+++ b/README.md
@@ -91,12 +91,12 @@ This is one of three components required for Project Lightspeed. Project Lightsp
     ```sh
     docker run -it --rm \
       -p 8000:80/tcp \
-      -e WEBSOCKET_HOST=localhost \
+      -e WEBSOCKET_HOST=lightspeed-websocket-hostname \
       -e WEBSOCKET_PORT=8080 \
       grvydev/lightspeed-react
     ```
 
-1. You can now access it at [localhost:8000](http://localhost:8000) and the websocket port is published on port `8080`.
+1. You can now access it at [localhost:8000](http://localhost:8000).
 
 ### Locally
 

--- a/README.md
+++ b/README.md
@@ -91,10 +91,12 @@ This is one of three components required for Project Lightspeed. Project Lightsp
     ```sh
     docker run -it --rm \
       -p 8000:80/tcp \
-      -e WEBSOCKET_HOST=lightspeed-websocket-hostname \
+      -e WEBSOCKET_HOST=localhost \
       -e WEBSOCKET_PORT=8080 \
       grvydev/lightspeed-react
     ```
+
+    Where your websocket host from the browser/client perspective is accessible on `localhost:8080`.
 
 1. You can now access it at [localhost:8000](http://localhost:8000).
 

--- a/docker/config.json.template
+++ b/docker/config.json.template
@@ -1,0 +1,3 @@
+{
+  "wsUrl": "ws://${WEBSOCKET_HOST}:${WEBSOCKET_PORT}/websocket"
+}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+publicDir=/usr/share/nginx/html
+
+envsubst < /config.json.template > "$publicDir/config.json"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,3 @@
 #!/bin/sh
 
-publicDir=/usr/share/nginx/html
-
-envsubst < /config.json.template > "$publicDir/config.json"
+envsubst < /config.json.template > "/usr/share/nginx/html/config.json"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-publicDir=/usr/share/nginx/html
-host=${WEBSOCKET_HOST:-localhost}
-
-# configure ip, hardcoded to webrtc container address (8080) for now
-sed -i "s|stream.gud.software|$host|g" "$publicDir/config.json"
-exec /bin/sh "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+publicDir=/usr/share/nginx/html
+host=${WEBSOCKET_HOST:-localhost}
+
+# configure ip, hardcoded to webrtc container address (8080) for now
+sed -i "s|stream.gud.software|$host|g" "$publicDir/config.json"
+exec /bin/sh "$@"


### PR DESCRIPTION
- [x] Shell entrypoint to run sed command using the environment variable `WEBSOCKET_HOST` and defaulting to localhost if it's not set. It then executes /bin/sh.
- [x] Faster Docker builds by caching node modules in a Docker layer for build
- [x] Pin Alpine and Node versions
- [x] Smaller final Docker image with alpine
- [x] ~Run without root as user with uid 1000, for security reasons 👀~  - will do with the Go entrypoint due to how nginx operates

- [x] ❓ We should have an http server in the Dockerfile, do you have any preference? Maybe nginx or a Go binary would be nice to keep the size lower than a node image with serve. I'm happy to hack one with Go, or you can use my ugly 1 line one (lol) from [this](https://github.com/qdm12/react-ts-template/blob/master/Dockerfile#L18-L21)
- [x] Add documentation once we're all happy