### PR TITLE
extra environment variables for configuring wsUrl (e.g., "wss://" instead of "ws://")

### DIFF
--- a/docker/config.json.template
+++ b/docker/config.json.template
@@ -1,3 +1,3 @@
 {
-  "wsUrl": "ws://${WEBSOCKET_HOST}:${WEBSOCKET_PORT}/websocket"
+  "wsUrl": "${WEBSOCKET_SCHEME}${WEBSOCKET_HOSTNAME}:${WEBSOCKET_PORT}/websocket"
 }

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
-envsubst < /config.json.template > "/usr/share/nginx/html/config.json"
+WEBSOCKET_SCHEME="${WEBSOCKET_SCHEME:-ws://}" \
+  WEBSOCKET_HOSTNAME="${WEBSOCKET_HOSTNAME:-${WEBSOCKET_HOST}}" \
+  envsubst < /config.json.template > "/usr/share/nginx/html/config.json"


### PR DESCRIPTION
in order to serve my Lightspeed-react Docker container over https, i've found that i need to configure wsUrl so that it uses the "wss://" scheme instead of "ws://". i also need to set the host to an actual domain name rather than an IP address, presumably because my SSL certificate is only valid for the former.

this patch makes it possible to do this by allowing the user to set WEBSOCKET_SCHEME and WEBSOCKET_HOSTNAME environment variables. if these are not set, they are replaced with "ws://" and $WEBSOCKET_HOST respectively, so the patch should be backwards compatible.
