### PR TITLE
Add playoutDelayHint to webrtc receiver for smoother video playback

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -41,9 +41,11 @@ const App = () => {
   pc.ontrack = (event) => {
     const {
       track: { kind },
+      receiver,
       streams,
     } = event;
 
+    receiver.playoutDelayHint = 1;
     if (kind === "video") {
       dispatch({ type: "initStream", stream: streams[0] });
     }


### PR DESCRIPTION
In general the idea is to alleviate stuttering that can occur even
without packet loss due to inconsistent packet timing by adding a small
buffer before playback.

This specific setting seems only partially supported and has changed
names several times. In the latest extensions spec[1], it is
defined as simply `playoutDelay` but only the slightly older name
`playoutDelayHint` property appears to have any effect on my testing for
Chrome 99.0.4844.51 on Windows 10. There appears to be an open issue to
add support for Firefox[2].

[1] https://w3c.github.io/webrtc-extensions/#rtcrtpreceiver-interface
[2] https://bugzilla.mozilla.org/show_bug.cgi?id=1592988